### PR TITLE
인가 + firestore Database에 user정보 저장

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChakraProvider, Container, extendTheme } from '@chakra-ui/react';
 import MainRouter from './router/MainRouter';
 import { BrowserRouter } from 'react-router-dom';
 import LoginRouter from './router/LoginRouter';
+import AuthProvider from './provider/authProvider';
 
 const theme = extendTheme({
   colors: {
@@ -13,18 +14,16 @@ const theme = extendTheme({
 function App() {
   console.log(theme);
   return (
-    <ChakraProvider theme={theme}>
-      <BrowserRouter>
-        <Container
-          minW="390px"
-          bg="white"
-          h="100vh"
-          position="relative">
-          <LoginRouter />
-          <MainRouter />
-        </Container>
-      </BrowserRouter>
-    </ChakraProvider>
+    <AuthProvider>
+      <ChakraProvider theme={theme}>
+        <BrowserRouter>
+          <Container minW="390px" bg="white" h="100vh" position="relative">
+            <LoginRouter />
+            <MainRouter />
+          </Container>
+        </BrowserRouter>
+      </ChakraProvider>
+    </AuthProvider>
   );
 }
 

--- a/src/pages/Login/UserInfo.tsx
+++ b/src/pages/Login/UserInfo.tsx
@@ -1,10 +1,27 @@
+import { useContext } from 'react';
+import { AuthContext } from '../../provider/authContext';
+import { auth } from '../../../firebase';
 
 const UserInfo = () => {
-  return (
-    <div style={{padding: 20, textAlign: 'center'}}>
-      내 정보
-    </div>
-  )
-}
+  const user = useContext(AuthContext);
+  console.log('유저는', user);
 
-export default UserInfo
+  const handleLogout = async () => {
+    try {
+      await auth.signOut();
+      alert('로그아웃 성공!');
+    } catch (error) {
+      console.error('로그아웃 실패: ', error);
+      alert('로그아웃 실패!');
+    }
+  };
+
+  return (
+    <>
+      <div style={{ padding: 20, textAlign: 'center' }}>내 정보</div>;
+      <button onClick={handleLogout}>로그아웃</button>
+    </>
+  );
+};
+
+export default UserInfo;

--- a/src/pages/Login/UserLogin.tsx
+++ b/src/pages/Login/UserLogin.tsx
@@ -17,6 +17,7 @@ import {
 } from 'firebase/auth';
 import { auth } from '../../../firebase';
 
+
 const UserLogin = () => {
   const navigate = useNavigate();
 
@@ -35,6 +36,7 @@ const UserLogin = () => {
       alert('로그인에 성공했습니다.');
       navigate('/shoot');
       const user = userCredential.user;
+      console.log(user.uid);
     } catch (e) {
       if (e.code === 'auth/invalid-email') {
         alert('이메일을 입력해주세요.');

--- a/src/pages/Login/UserLogin.tsx
+++ b/src/pages/Login/UserLogin.tsx
@@ -17,7 +17,6 @@ import {
 } from 'firebase/auth';
 import { auth } from '../../../firebase';
 
-
 const UserLogin = () => {
   const navigate = useNavigate();
 
@@ -26,7 +25,6 @@ const UserLogin = () => {
 
   const handleLoginSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log(`아이디: ${email}, 비밀번호: ${password}`);
     try {
       const userCredential = await signInWithEmailAndPassword(
         auth,
@@ -36,7 +34,6 @@ const UserLogin = () => {
       alert('로그인에 성공했습니다.');
       navigate('/shoot');
       const user = userCredential.user;
-      console.log(user.uid);
     } catch (e) {
       if (e.code === 'auth/invalid-email') {
         alert('이메일을 입력해주세요.');
@@ -46,7 +43,6 @@ const UserLogin = () => {
         alert('로그인에 실패했습니다.');
       }
       const errorCode = e.code;
-      console.log(errorCode);
     }
   };
 

--- a/src/provider/authContext.tsx
+++ b/src/provider/authContext.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { User } from '@firebase/auth';
+
+export const AuthContext = React.createContext<User | null>(null);

--- a/src/provider/authProvider.tsx
+++ b/src/provider/authProvider.tsx
@@ -1,0 +1,24 @@
+import { User } from '@firebase/auth';
+import { useEffect, useState } from 'react';
+import { AuthContext } from './authContext';
+import { auth } from '../../firebase';
+
+interface IChildren {
+  children: React.JSX.Element;
+}
+
+const AuthProvider = ({ children }: IChildren) => {
+  const [user, setUser] = useState<User | null>(null);
+
+
+  useEffect(() => {
+    const subscribe = auth.onAuthStateChanged((fbUser) => {
+      setUser(fbUser);
+    });
+    return subscribe;
+  }, []);
+
+  return <AuthContext.Provider value={user}>{children}</AuthContext.Provider>;
+};
+
+export default AuthProvider;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
close #10 

## 작업 내용 (변경 사항)
- 회원가입시 닉네임 유효성검사
- 회원가입시 `user` 데이터 생성
- 인가구현(`App.tsx`에 `AuthProvider` 추가)
## 스크린샷
- 받은사진, 보낸사진을 `user.uid`(문서제목 = uid)의 값으로 특정하여 `receiveImg`, `sendImg`에 저장하면됨
![image](https://github.com/Tashyung/photo-projects/assets/134940630/a6bc6c89-361e-4178-8360-ca784265cbe7)


## 테스트 결과
- 문제없음
## 리뷰 요청 사항 및 전달사항
- 추후 헤더 등에 로그인상태를 보여주고 로그아웃할수있는 컴포넌트 필요
- `const user = useContext(AuthContext);`로 로그인유무와 로그인한 유저의 정보를 가져올수있음(user.uid)
## Check list
- [ ] 테스트 통과
- [ ] 문서 업데이트
